### PR TITLE
Set up CI/CD and add worker test

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on: [push, pull_request]
 
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
+      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -17,15 +19,13 @@ jobs:
           python-version: 3.9
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
-      - name: install dependencies and test
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies and test
         shell: bash
         run: |
           npm install
           npm test
-      - name: build with node-gyp
+      - name: Build with node-gyp
         shell: bash
         run: |
-          npm install -g node-gyp
-          node-gyp configure
-          node-gyp rebuild
+          npm run prebuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  prebuilds:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+          - os: macos-latest
+            arch: x64
+          - os: windows-latest
+            arch: x86
+          - os: windows-latest
+            arch: x64
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.os }} ${{ matrix.arch }}
+    env:
+      NODE_VERSION: 16
+      VERSION_NAME: ${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Set up node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          node-version: ${{ env.NODE_VERSION }}
+          architecture: ${{ matrix.arch }}
+      - name: Install dependencies
+        shell: bash
+        run: npm install --build-from-source
+      - name: Prebuild ${{ env.VERSION_NAME }}
+        shell: bash
+        run: npm run prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false
+      - name: Create artifact
+        shell: bash
+        run: |
+          tar -zcvf $ARCHIVE_NAME -C prebuilds .
+          stat "$ARCHIVE_NAME"
+        env:
+          ARCHIVE_NAME: ${{ env.VERSION_NAME }}.tar.gz
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.VERSION_NAME }}
+          path: ${{ env.VERSION_NAME }}.tar.gz
+          retention-days: 1
+
+  release_and_publish:
+    runs-on: ubuntu-latest
+    needs: prebuilds
+    permissions:
+      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Set up node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: prebuilds
+      - name: Create ${{ github.ref }} release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: prebuilds/*/*.tar.gz
+        env:
+          ARCHIVE_NAME: ${{ github.ref_name }}-${{ runner.os }}-${{ runner.arch }}.tar
+      - run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "scripts": {
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi --tag-armv --tag-uv",
-    "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))",
     "test": "node-gyp rebuild --directory test && nyc mocha --expose-gc --reporter spec"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphacep/ffi-napi",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "license": "MIT",
   "author": "Anna Henningsen <anna@addaleax.net>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ffi-napi",
+  "name": "@alphacep/ffi-napi",
   "version": "4.0.3",
   "license": "MIT",
   "author": "Anna Henningsen <anna@addaleax.net>",
@@ -30,7 +30,7 @@
     "get-uv-event-loop-napi-h": "^1.0.5",
     "node-addon-api": "^3.0.0",
     "node-gyp-build": "^4.2.1",
-    "ref-napi": "../ref-napi-ng",
+    "ref-napi": "npm:@alphacep/ref-napi@4.0.1",
     "ref-struct-di": "^1.1.0"
   },
   "devDependencies": {

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,0 +1,25 @@
+'use strict';
+const { Worker } = require('worker_threads');
+
+describe('Worker', function () {
+  it('should not throw and error when required inside Worker', function (done) {
+    const worker = new Worker(`require('./');`, { eval: true });
+    worker.on('exit', (code) => {
+      if (code !== 0) {
+        throw new Error(`Worker stopped with exit code ${code}`);
+      }
+      done();
+    });
+  });
+
+  it('should not trigger a segfault when required outside and inside a Worker', function (done) {
+    require('../');
+    const worker = new Worker(`require('./');`, { eval: true });
+    worker.on('exit', (code) => {
+      if (code !== 0) {
+        throw new Error(`Worker stopped with exit code ${code}`);
+      }
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Setup a __test__ workflow, ex:
https://github.com/larriereguichet/alphacep-node-ffi-napi/actions/runs/1531317470

Setup a __release__ workflow, ex:
https://github.com/larriereguichet/alphacep-node-ffi-napi/releases/tag/4.0.4

Then I recommend to:
1. Merge https://github.com/alphacep/ref-napi/pull/1 and wait until the release process has succeeded.
2. ~~Create an `alphacep` organisation on npm (if not already):~~
~~https://www.npmjs.com/org/create~~
3. ~~Generate a *publish* npm access token:~~
~~https://www.npmjs.com/settings/nshmyrev/tokens~~
4. Add it as `NPM_TOKEN` to the repository secrets (or add an __organization__ wide one, then you're done once and for all)
https://github.com/alphacep/ref-napi/settings/secrets/actions
5. Push a new tag to publish the new release:
```
git tag -f 4.0.4
git push origin --tags
```